### PR TITLE
Fix the unexpected EOFException from getAlbum

### DIFF
--- a/src/io/laniakia/util/JSONUtil.java
+++ b/src/io/laniakia/util/JSONUtil.java
@@ -96,12 +96,15 @@ public class JSONUtil
 	
 	public static List<JsonObject> getTrackInfo(String json)
 	{
-		Gson gson = new Gson();
 		List<JsonObject> jsonTrackList = new ArrayList<JsonObject>();
-		JsonStreamParser parser = new JsonStreamParser( new StringReader(json.replace("},{", "}{")));
-		while (parser.hasNext())
+		if (StringUtils.isNotBlank(json))
 		{
-			jsonTrackList.add(gson.fromJson(parser.next(),JsonObject.class));
+			Gson gson = new Gson();
+			JsonStreamParser parser = new JsonStreamParser( new StringReader(json.replace("},{", "}{")));
+			while (parser.hasNext())
+			{
+				jsonTrackList.add(gson.fromJson(parser.next(),JsonObject.class));
+			}
 		}
 		return jsonTrackList;
 	}

--- a/test/net/cypher/test/APITest.java
+++ b/test/net/cypher/test/APITest.java
@@ -103,4 +103,12 @@ public class APITest
 		album = b.getAlbum("parallels", "visionaries");
 		assertTrue(album != null);
 	}
+	
+	@Test
+	public void testGetAlbumWithNoTrackInfoProvided() throws Exception
+	{
+		BandcampAPI b = new BandcampAPI();
+		Album album = b.getAlbum("https://ghostbath.bandcamp.com/album/moonlover");
+		assertTrue(album != null);
+	}
 }


### PR DESCRIPTION
Handle the situation when trackinfo in a bandcamp album page is empty
e.g. [https://ghostbath.bandcamp.com/album/moonlover](url)
, which threw EOFException by the JsonStreamParser.